### PR TITLE
Fix #79 parsing hardcoded to 'en' code

### DIFF
--- a/GapsWeb/src/main/java/com/jasonhhouse/gaps/service/GapsSearchService.java
+++ b/GapsWeb/src/main/java/com/jasonhhouse/gaps/service/GapsSearchService.java
@@ -76,6 +76,10 @@ import org.xml.sax.SAXException;
 @Service
 public class GapsSearchService implements GapsSearch {
 
+    public static final String ID_IDX_START = "://";
+
+    public static final String ID_IDX_END = "?";
+
     private final Logger logger = LoggerFactory.getLogger(GapsSearchService.class);
 
     private final Set<Movie> searched;
@@ -586,11 +590,12 @@ public class GapsSearchService implements GapsSearch {
                         }
 
                         Movie movie;
+
                         if (guid.contains("com.plexapp.agents.themoviedb")) {
-                            guid = guid.substring(guid.indexOf("://")+3, guid.indexOf("?lang="));
+                            guid = guid.substring(guid.indexOf(ID_IDX_START)+ ID_IDX_START.length(), guid.indexOf(ID_IDX_END));
                             movie = new Movie(Integer.parseInt(guid), title, Integer.parseInt(year), "");
                         } else if (guid.contains("com.plexapp.agents.imdb://")) {
-                            guid = guid.substring(guid.indexOf("://")+3, guid.indexOf("?"));
+                            guid = guid.substring(guid.indexOf(ID_IDX_START)+ ID_IDX_START.length(), guid.indexOf(ID_IDX_END));
                             movie = new Movie(guid, title, Integer.parseInt(year), "");
                         } else {
                             logger.warn("Cannot handle guid value of " + guid);

--- a/GapsWeb/src/main/java/com/jasonhhouse/gaps/service/GapsSearchService.java
+++ b/GapsWeb/src/main/java/com/jasonhhouse/gaps/service/GapsSearchService.java
@@ -587,14 +587,10 @@ public class GapsSearchService implements GapsSearch {
 
                         Movie movie;
                         if (guid.contains("com.plexapp.agents.themoviedb")) {
-                            guid = guid.replace("com.plexapp.agents.themoviedb://", "");
-                            guid = guid.replace("?lang=en", "");
-
+                            guid = guid.substring(guid.indexOf("://")+3, guid.indexOf("?lang="));
                             movie = new Movie(Integer.parseInt(guid), title, Integer.parseInt(year), "");
                         } else if (guid.contains("com.plexapp.agents.imdb://")) {
-                            guid = guid.replace("com.plexapp.agents.imdb://", "");
-                            guid = guid.replace("?lang=en", "");
-
+                            guid = guid.substring(guid.indexOf("://")+3, guid.indexOf("?"));
                             movie = new Movie(guid, title, Integer.parseInt(year), "");
                         } else {
                             logger.warn("Cannot handle guid value of " + guid);


### PR DESCRIPTION
Fixes #79 Fixed parsing of guid language by using sub-string to retrieve id instead of hard-coding language code.