### PR TITLE
Dockerfile: Change exposed port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="jh5975@gmail.com"
 LABEL name="Jason House" 
 LABEL github="https://github.com/JasonHHouse/Gaps" 
 
-EXPOSE 32400
+EXPOSE 8484
 
 RUN apt-get -y update
 


### PR DESCRIPTION
Port 32400 is not used within the container (expose has nothing to do with outbound traffic). Changed it to 8484 in order to allow for service discovery to function correctly when using stuff like reverse proxies.