### PR TITLE
Add docker manifest support to allow multi-arch images

### DIFF
--- a/build
+++ b/build
@@ -18,11 +18,20 @@ npm ci
 ./minify
 npm run test
 mvn clean install
-docker buildx build --platform linux/s390x,linux/amd64 -t housewrecker/gaps:latest -f Dockerfile --push .
+docker buildx build --platform linux/s390x,linux/amd64 -t housewrecker/gaps:s390x-latest -t housewrecker/gaps:amd64-latest -f Dockerfile --push .
 docker buildx build --platform linux/riscv64 -t housewrecker/gaps:risc-latest -f Dockerfile.riscv64 --push .
 docker buildx build --platform linux/ppc64le -t housewrecker/gaps:ppc64le-latest -f Dockerfile.ppc64le --push .
 docker buildx build --platform linux/arm64 -t housewrecker/gaps:arm-latest -f Dockerfile.arm64 --push .
 docker buildx build --platform linux/arm/v7 -t housewrecker/gaps:arm32v7-latest -f Dockerfile.arm32v7 --push .
+
+docker manifest create housewrecker/gaps:latest \
+  -a housewrecker/gaps:amd64-latest \
+  -a housewrecker/gaps:risc-latest \
+  -a housewrecker/gaps:ppc64le-latest \
+  -a housewrecker/gaps:arm-latest \
+  -a housewrecker/gaps:arm32v7-latest \
+  -a housewrecker/gaps:s390x-latest
+docker manifest push housewrecker/gaps:latest
 
 ## Making Windows/Linux/Mac Zip
 mkdir -p GapsOnWindows


### PR DESCRIPTION
Replaces `latest` with a multi-arch manifest. This means that pulling `homewrecker/gaps:latest` will work on any supported architecture.
Create `amd64-latest` and `s309x-latest` tags to be inclded with new latest manifest.

See [adamus1red/gaps](https://hub.docker.com/r/adamus1red/gaps/tags) for example.